### PR TITLE
Fix for in case Array is not there

### DIFF
--- a/Classes/Hooks/BackendUtility.php
+++ b/Classes/Hooks/BackendUtility.php
@@ -43,8 +43,10 @@ class BackendUtility extends \GeorgRinger\News\Hooks\BackendUtility {
 
 		if ($params['selectedView'] === 'News->month' || $params['selectedView'] === 'News->list') {
 			$eventRestrictionXml = GeneralUtility::xml2array($this->eventRestrictionField);
-			$params['dataStructure']['sheets']['sDEF']['ROOT']['el'] = $params['dataStructure']['sheets']['sDEF']['ROOT']['el'] + array(
+			if (is_array($params['dataStructure']['sheets']['sDEF']['ROOT']['el'])) {
+				$params['dataStructure']['sheets']['sDEF']['ROOT']['el'] = $params['dataStructure']['sheets']['sDEF']['ROOT']['el'] + array(
 					'settings.eventRestriction' => $eventRestrictionXml);
+			}
 		}
 	}
 }


### PR DESCRIPTION
# Bugreport and Fix for EXT "eventnews"
# ERROR in eventnews, beim Editieren des Plugins News im Backend:

Fatal error: Unsupported operand types in /srv/www/www/typo3conf/ext/eventnews/Classes/Hooks/BackendUtility.php on line 47
